### PR TITLE
Enable dynamic refreshing of client issue mapping from Jira

### DIFF
--- a/.config/nicknames-example.json
+++ b/.config/nicknames-example.json
@@ -1,0 +1,5 @@
+{
+    "Nickname For JIRA issue" : "ABC-1",
+    "Also a nickname"         : "ABC-1",
+    "Nick2"                   : "ABC-5"
+}

--- a/class-jirify-jira.php
+++ b/class-jirify-jira.php
@@ -4,17 +4,20 @@ class Jirify_Jira extends Jirify {
 	private $token;
 	private $email;
 	private $endpoint;
+	private $project_key;
 
-	public function __construct( $token, $email, $endpoint ) {
+	public function __construct( $token, $email, $endpoint, $project_key ) {
 		$this->token          = $token;
 		$this->email          = $email;
 		$this->endpoint       = $endpoint;
+		$this->project_key    = $project_key;
+		$this->client_mapping = $this->get_client_mapping();
 	}
 
 	public function send_worklog( $client, $seconds, $desc = '', $date ) {
 		// Normalize strings.
 		$lc_client = strtolower( trim( $client ) );
-		$client_mapping = $this->get_client_mapping();
+		$client_mapping = $this->client_mapping;
 
 		$worklogs  = array_change_key_case( $client_mapping );
 
@@ -53,5 +56,62 @@ class Jirify_Jira extends Jirify {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Gets the Client Name to Jira issue key mapping
+	 *
+	 * @return array An array of "client name" => "jira issue key" pairs.
+	 */
+	public function get_client_mapping() {
+		// Try and get client mapping from cache.
+		$cached_mapping = $this->get_cache_data( 'mapping' );
+		if ( $cached_mapping ) {
+			return (array) $cached_mapping;
+		}
+
+		$this->line( "♻️  Refreshing Jira client mapping." );
+
+		$url = sprintf(
+			'%s/rest/api/3/search',
+			$this->endpoint
+		);
+	
+		$args = array(
+			'headers' => array(
+				'Authorization: Basic ' . base64_encode( $this->email . ':' . $this->token ),
+				'Accept: application/json',
+			),
+			'body'    => json_encode(
+				array(
+					// This search is specific to my Jira setup. https://support.atlassian.com/jira-software-cloud/docs/advanced-search-reference-jql-fields/
+					'jql' => 'project = ' . $this->project_key . ' AND issuetype = Client AND resolution = unresolved order by summary ASC',
+					// I'm pretty sure that 100 is the absolute max here.
+					'maxResults' => 100,
+				)
+			),
+		);
+	
+		$result = $this->remote_post( $url, $args );
+
+		$issue_mapping = [];
+
+		if ( isset( $result['response'] ) ) {
+			foreach ( $result['response']->issues as $issue ) {
+				$issue_mapping[ $issue->fields->summary ] = $issue->key;
+			}
+		}
+
+		// Now get any nicknames we have.
+		if ( file_exists( dirname( __FILE__ ) . '/.config/nicknames.json' ) ) {
+			$nicknames = (array) json_decode( file_get_contents( dirname( __FILE__ ) . '/.config/nicknames.json' ) );
+
+			// Merge them in.
+			$issue_mapping = array_merge( $issue_mapping, $nicknames );
+		}
+
+		// Sets the mapping data in the cache for 12 hours.
+		$this->set_cache_data( 'mapping', $issue_mapping );
+		return $issue_mapping;
 	}
 }


### PR DESCRIPTION
Before, we needed to manually maintain a list of all Jira issues from our board. Any time we needed to add a new customer, we also had to update our local mapping file.

This commit makes it so we can now retrieve and cache that mapping data for 12 hours. Now, if we have a new customer, the file will be updated (assuming it's expired) and we'll only have to add a nickname to `./config/nicknames.json` if we have one.