### PR TITLE
Flag worklog match error in dry runs

### DIFF
--- a/class-jirify-clockify.php
+++ b/class-jirify-clockify.php
@@ -98,7 +98,11 @@ class Jirify_Clockify extends Jirify {
 				if ( $start > $dry_last_logged_start ) {
 					$dry_last_logged_start = $start;
 				}
-				$this->line( "✅ Would have logged " . $this->get_friendly_duration_output( $duration ) . " for " . $client->name . $description_output );
+				if ( ! $this->jira->get_issue_id_from_client( $client->name ) ) {
+					$this->line( "❌ Would not have logged " . $this->get_friendly_duration_output( $duration ) . " for " . $client->name . ' - Could not find a Worklog match' );
+				} else {
+					$this->line( "✅ Would have logged " . $this->get_friendly_duration_output( $duration ) . " for " . $client->name . $description_output );
+				}
 			} else {
 				$this->line( "❌ Error logging " . $this->get_friendly_duration_output( $duration ) . " for " . $client->name . $description_output );
 			}

--- a/class-jirify-jira.php
+++ b/class-jirify-jira.php
@@ -15,18 +15,11 @@ class Jirify_Jira extends Jirify {
 	}
 
 	public function send_worklog( $client, $seconds, $desc = '', $date ) {
-		// Normalize strings.
-		$lc_client = strtolower( trim( $client ) );
-		$client_mapping = $this->client_mapping;
-
-		$worklogs  = array_change_key_case( $client_mapping );
-
-		if ( array_key_exists( $lc_client, $worklogs ) ) {
-			$lc_client = $worklogs[ $lc_client ];
-		}
+		// Get the issue ID for this client
+		$issue_id = $this->get_issue_id_from_client( $client );
 
 		// No match found!
-		if ( strtolower( trim( $client ) ) === $lc_client ) {
+		if ( ! $issue_id ) {
 			$this->line( sprintf( '❌ Could not find a Worklog match for client "%s"', $client ) );
 			return false;
 		}
@@ -34,7 +27,7 @@ class Jirify_Jira extends Jirify {
 		$url = sprintf(
 			'%s/rest/api/3/issue/%s/worklog',
 			$this->endpoint,
-			rawurlencode( $lc_client ),
+			rawurlencode( $issue_id ),
 		);
 
 		$args = array(
@@ -56,6 +49,30 @@ class Jirify_Jira extends Jirify {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Gets an issue ID from the client mapping.
+	 *
+	 * @param string $client The client name to check.
+	 * @return string|bool The Jira issue ID, or false if no match found.
+	 */
+	public function get_issue_id_from_client( $client ) {
+		// Normalize strings.
+		$lc_client = strtolower( trim( $client ) );
+		$client_mapping = $this->client_mapping;
+
+		$worklogs  = array_change_key_case( $client_mapping );
+
+		if ( array_key_exists( $lc_client, $worklogs ) ) {
+			$issue_id = $worklogs[ $lc_client ];
+		}
+
+		if ( ! isset( $issue_id ) ) {
+			return false;
+		}
+
+		return $issue_id;
 	}
 
 	/**

--- a/class-jirify-toggl.php
+++ b/class-jirify-toggl.php
@@ -89,7 +89,11 @@ class Jirify_Toggl extends Jirify {
 				if ( $start > $dry_last_logged_start ) {
 					$dry_last_logged_start = $start;
 				}
-				$this->line( "✅ Would have logged " . $this->get_friendly_duration_output( $duration ) . " for " . $client->name . $description_output );
+				if ( ! $this->jira->get_issue_id_from_client( $client->name ) ) {
+					$this->line( "❌ Would not have logged " . $this->get_friendly_duration_output( $duration ) . " for " . $client->name . ' - Could not find a Worklog match' );
+				} else {
+					$this->line( "✅ Would have logged " . $this->get_friendly_duration_output( $duration ) . " for " . $client->name . $description_output );
+				}
 			} else {
 				$this->line( "❌ Error logging " . $this->get_friendly_duration_output( $duration ) . " for " . $client->name . $description_output );
 			}


### PR DESCRIPTION
Adds a method to get the Jira issue ID from a client mapping string. We were doing this manually in `send_worklog()` before. This meant that if you were doing a dry run and had a worklog mismatch, it would have falsely reported that the worklog would have been logged. Breaking this out into its own method, means that the time tracking service classes can use it to check for a match during dry runs.

Then we use the new `Jirify_Jira::get_issue_id_from_client()` method in our time tracking service classes to make sure there's a match for the worklog during a dry run.
